### PR TITLE
Authentication in Schema Registry

### DIFF
--- a/src/go/k8s/controllers/redpanda/console_controller.go
+++ b/src/go/k8s/controllers/redpanda/console_controller.go
@@ -43,7 +43,11 @@ const (
 
 	schemaRegistryTLSKeyFilepath  = tlsPath + "/tls.key"
 	schemaRegistryTLSCertFilepath = tlsPath + "/tls.crt"
-	schemaRegistryTLSCAFilepath   = tlsPath + "/ca.crt"
+	// We are using publicly signed certificates for TLS
+	// Console is creating a NewCertPool() which will not use host default certificates when left blank
+	// REF https://github.com/redpanda-data/console/blob/master/backend/pkg/schema/client.go#L60
+	// This should be fixed upstream
+	schemaRegistryTLSCAFilepath = "/etc/ssl/certs/ca-certificates.crt"
 
 	configMount = "config"
 	configPath  = "/etc/console/configs/config.yaml"


### PR DESCRIPTION
Use mTLS to authenticate to Schema Registry. `BasicAuth` also works if credentials are passed but preferred mTLS.

This PR introduces:
- Mount the mTLS certificates used for authentication:
  - Have to pass host default `ca-certificates`. [REF](https://github.com/redpanda-data/console/blob/master/backend/pkg/schema/client.go#L60)
- Add `getSchemaRegistryURL()` which prefers `Internal` host and `http` scheme.

Notes:
- Care for Kafka auth if mTLS is enabled (most likely in a separate PR)
