### PR TITLE
Minor fixes

### DIFF
--- a/src/go/k8s/controllers/redpanda/console_controller.go
+++ b/src/go/k8s/controllers/redpanda/console_controller.go
@@ -330,6 +330,9 @@ func (r *ConsoleReconciler) createDeployment(ctx context.Context, cluster *redpa
 			Replicas: console.Spec.Deployment.Replicas,
 			Selector: consoleLabels.AsAPISelector(),
 			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: consoleLabels,
+				},
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{

--- a/src/go/k8s/controllers/redpanda/console_controller.go
+++ b/src/go/k8s/controllers/redpanda/console_controller.go
@@ -394,16 +394,11 @@ func (r *ConsoleReconciler) createDeployment(ctx context.Context, cluster *redpa
 }
 
 func getContainers(cluster *redpandav1alpha1.Cluster, console *redpandav1alpha1.Console) []corev1.Container {
-	var args []string
-	if cluster.Spec.EnableSASL {
-		args = append(args, "--kafka.sasl.password=$(KAFKA_SASL_PASSWORD)")
-	}
-
 	return []corev1.Container{
 		{
 			Name:  "console",
 			Image: fmt.Sprintf("%s:%s", console.Spec.Image, console.Spec.Version),
-			Args:  append(args, fmt.Sprintf("--config.filepath=%s/%s", configPath, "config.yaml")),
+			Args:  []string{fmt.Sprintf("--config.filepath=%s/%s", configPath, "config.yaml")},
 			Ports: []corev1.ContainerPort{
 				{
 					Name:          "http",

--- a/src/go/k8s/controllers/redpanda/console_controller.go
+++ b/src/go/k8s/controllers/redpanda/console_controller.go
@@ -431,7 +431,9 @@ func getDNSPolicy(console *redpandav1alpha1.Console) corev1.DNSPolicy {
 	if console.Spec.Deployment.DNSPolicy != nil {
 		return *console.Spec.Deployment.DNSPolicy
 	}
-	return corev1.DNSDefault
+	// This is the default set by K8s. Otherwise Service DNS will not be resolvable.
+	// REF https://kubernetes.io/docs/tasks/administer-cluster/dns-debugging-resolution/#known-issues
+	return corev1.DNSClusterFirst
 }
 
 func getDeploymentStrategy(console *redpandav1alpha1.Console) v1.DeploymentStrategy {

--- a/src/go/k8s/controllers/redpanda/console_controller.go
+++ b/src/go/k8s/controllers/redpanda/console_controller.go
@@ -409,7 +409,7 @@ func getContainers(cluster *redpandav1alpha1.Cluster, console *redpandav1alpha1.
 				{
 					Name:          "http",
 					ContainerPort: int32(console.Spec.REST.HTTPListenPort),
-					Protocol:      "tcp",
+					Protocol:      "TCP",
 				},
 			},
 			Env:       []corev1.EnvVar{},

--- a/src/go/k8s/controllers/redpanda/console_controller.go
+++ b/src/go/k8s/controllers/redpanda/console_controller.go
@@ -401,10 +401,9 @@ func getContainers(cluster *redpandav1alpha1.Cluster, console *redpandav1alpha1.
 
 	return []corev1.Container{
 		{
-			Name:    "console",
-			Image:   fmt.Sprintf("%s:%s", console.Spec.Image, console.Spec.Version),
-			Command: []string{"/app/console"},
-			Args:    append(args, fmt.Sprintf("--config.filepath=%s/%s", configPath, "config.yaml")),
+			Name:  "console",
+			Image: fmt.Sprintf("%s:%s", console.Spec.Image, console.Spec.Version),
+			Args:  append(args, fmt.Sprintf("--config.filepath=%s/%s", configPath, "config.yaml")),
 			Ports: []corev1.ContainerPort{
 				{
 					Name:          "http",

--- a/src/go/k8s/controllers/redpanda/console_controller.go
+++ b/src/go/k8s/controllers/redpanda/console_controller.go
@@ -43,7 +43,7 @@ const (
 	schemaRegistryTLSCAFilepath   = "/redpanda/schema-registry/ca.pem"
 
 	configMount = "config"
-	configPath  = "/etc/console/configs/config.yaml"
+	configPath  = "/etc/console/configs"
 )
 
 // ConsoleReconciler reconciles a Console object
@@ -404,7 +404,7 @@ func getContainers(cluster *redpandav1alpha1.Cluster, console *redpandav1alpha1.
 			Name:    "console",
 			Image:   fmt.Sprintf("%s:%s", console.Spec.Image, console.Spec.Version),
 			Command: []string{"/app/console"},
-			Args:    append(args, fmt.Sprintf("--config.filepath=%s", configPath)),
+			Args:    append(args, fmt.Sprintf("--config.filepath=%s/%s", configPath, "config.yaml")),
 			Ports: []corev1.ContainerPort{
 				{
 					Name:          "http",


### PR DESCRIPTION
Typos, defaults, and other minor fixes.

This PR fixes:
- Missing labels in `PodTemplate` spec of `Deployment`
- Fix typo in container port from `tcp` to `TCP`
- Fix `config.yaml` is a directory in `VolumeMounts`
- Fix custom command in container image is not found
- Use default `dnsPolicy=ClusterFirst` as this is default set by K8s. Otherwise, `Service` DNS will not be resolvable
- Remove container args to set `KAFKA_SASL_PASSWORD` via envar as this should be set in `ConfigMap`